### PR TITLE
Development -- Weighted Grades Use Points Not Grades

### DIFF
--- a/ConjureGrade/ConjureGrade.Tests/CourseWizardTests.cs
+++ b/ConjureGrade/ConjureGrade.Tests/CourseWizardTests.cs
@@ -95,5 +95,43 @@ namespace ConjureGrade.Tests
 
             testClass.UpdateAllGrades();
         }
+
+        [Fact]
+        public void UpdateOverAllGrade_NoScoreEvals_Equal100()
+        {
+            var testClass = Create_CourseWizard();
+
+            var final = new EvaluationResult { Weighted = true, WeightAmount = .4, PointValuePerScore = 100, PointsEarned = 0, PointsPossibleOverall = 100,  PointsPossibleToDate = 0,  };
+            var exams = new EvaluationResult { Weighted = true, WeightAmount = .3, PointValuePerScore = 100, PointsEarned = 175, PointsPossibleOverall = 300, PointsPossibleToDate = 200 };
+            var quiz = new EvaluationResult { Weighted = true, WeightAmount = .2, PointValuePerScore = 100, PointsEarned = 342, PointsPossibleOverall = 400, PointsPossibleToDate = 400 };
+            var hw = new EvaluationResult { Weighted = true, WeightAmount = .1, PointValuePerScore = 100, PointsEarned = 0, PointsPossibleOverall = 800, PointsPossibleToDate = 0 };
+
+            //var final = new EvaluationResult { PointsPossibleOverall = 100, TotalScoreCount = 1, PointsEarned = 0, GradeToDateRaw = 1, GradeOverallRaw = 0, Weighted = true, WeightAmount = .4, PointsPossibleToDate = 0, PointValuePerScore = 100 };
+            //var exams = new EvaluationResult { Weighted = true, WeightAmount = .3, TotalScoreCount = 3, PointValuePerScore = 100, PointsEarned = 175, PointsPossibleOverall = 300, PointsPossibleToDate = 200, GradeToDateRaw = .88, GradeOverallRaw = .58, };
+            //var quiz = new EvaluationResult { Weighted = true, WeightAmount = .2, TotalScoreCount = 4, PointValuePerScore = 100, PointsEarned = 342, PointsPossibleOverall = 400, PointsPossibleToDate = 400, GradeToDateRaw = .86, GradeOverallRaw = .86 };
+            //var hw = new EvaluationResult { Weighted = true, WeightAmount = .1, TotalScoreCount = 8, PointValuePerScore = 100, PointsEarned = 0, PointsPossibleOverall = 800, PointsPossibleToDate = 0, GradeToDateRaw = 1, GradeOverallRaw = 0 };
+
+            //var final = new EvaluationResult { PointsPossibleOverall = 100, PointsEarned = 0, Weighted = true, WeightAmount = .4 };
+            //var exams = new EvaluationResult { Weighted = true, WeightAmount = .3, PointsEarned = 175, PointsPossibleOverall = 300, };
+            //var quiz = new EvaluationResult { Weighted = true, WeightAmount = .2, PointsEarned = 342, PointsPossibleOverall = 400 };
+            //var hw = new EvaluationResult { Weighted = true, WeightAmount = .1, PointsEarned = 0, PointsPossibleOverall = 800 };
+
+            var courseResult = new WeightedCourseResult
+            {
+                Evaluations = new List<EvaluationResult>
+            {
+                final,
+                exams,
+                quiz,
+                hw
+            }
+            };
+
+            testClass.Course = courseResult;
+
+            testClass.UpdateGradeOverall();
+
+            testClass.Course.GradeOverallFriendly.ShouldBe(35);
+        }
     }
 }

--- a/ConjureGrade/ConjureGrade/ConjureGrade.nuspec
+++ b/ConjureGrade/ConjureGrade/ConjureGrade.nuspec
@@ -11,8 +11,8 @@
     <projectUrl>https://github.com/jdmac020/ConjureGrade</projectUrl>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
     <description>$description$</description>
-    <releaseNotes>Initial beta release</releaseNotes>
+    <releaseNotes>Beta 1.1--Changed weighted course calculation, easier grade access via properties in Wizard</releaseNotes>
     <copyright>Copyright 2018</copyright>
-    <tags>C# grades calculator</tags>
+    <tags>C# academic grade calculator</tags>
   </metadata>
 </package>

--- a/ConjureGrade/ConjureGrade/Properties/AssemblyInfo.cs
+++ b/ConjureGrade/ConjureGrade/Properties/AssemblyInfo.cs
@@ -32,5 +32,5 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("0.9.0.0")]
-[assembly: AssemblyFileVersion("0.9.0.0")]
+[assembly: AssemblyVersion("0.9.1.0")]
+[assembly: AssemblyFileVersion("0.9.1.0")]

--- a/ConjureGrade/ConjureGrade/Wizards/CourseWizard.cs
+++ b/ConjureGrade/ConjureGrade/Wizards/CourseWizard.cs
@@ -10,6 +10,14 @@ namespace ConjureGrade.Wizards
     /// </summary>
     public class CourseWizard : ICourseWizard
     {
+        public double OverallGradeFriendly { get { return Course.GradeOverallFriendly; } }
+
+        public double OverallGradeRaw { get { return Course.GradeOverallRaw; } }
+
+        public double ToDateGradeFriendly { get { return Course.GradeToDateFriendly; } }
+
+        public double ToDateGradeRaw { get { return Course.GradeToDateRaw; } }
+
         public ICourseResult Course { get; set; }
 
         /// <summary>
@@ -53,7 +61,7 @@ namespace ConjureGrade.Wizards
 
         protected void ProcessNonWeightedGrade(bool overallGrade)
         {
-            var castedCourse = (CourseResult) Course;
+            var castedCourse = (CourseResult)Course;
 
             castedCourse.PointsEarned = castedCourse.PointsEarned = castedCourse.Evaluations.Sum(e => e.PointsEarned);
 
@@ -98,7 +106,7 @@ namespace ConjureGrade.Wizards
                 if (overallGrade)
                 {
                     var weightedGrade = CalculateRawPercentage(eval.PointsEarned, eval.PointsPossibleOverall) * eval.WeightAmount;
-                   // var weightedGrade = eval.GradeOverallRaw * eval.WeightAmount;
+                    // var weightedGrade = eval.GradeOverallRaw * eval.WeightAmount;
                     totalGrade += weightedGrade;
                 }
                 else
@@ -108,7 +116,7 @@ namespace ConjureGrade.Wizards
                 }
             }
 
-            return Math.Round(totalGrade,2);
+            return Math.Round(totalGrade, 2);
         }
     }
 }

--- a/ConjureGrade/ConjureGrade/Wizards/CourseWizard.cs
+++ b/ConjureGrade/ConjureGrade/Wizards/CourseWizard.cs
@@ -97,12 +97,13 @@ namespace ConjureGrade.Wizards
             {
                 if (overallGrade)
                 {
-                    var weightedGrade = eval.GradeOverallRaw * eval.WeightAmount;
+                    var weightedGrade = CalculateRawPercentage(eval.PointsEarned, eval.PointsPossibleOverall) * eval.WeightAmount;
+                   // var weightedGrade = eval.GradeOverallRaw * eval.WeightAmount;
                     totalGrade += weightedGrade;
                 }
                 else
                 {
-                    var weightedGrade = eval.GradeToDateRaw * eval.WeightAmount;
+                    var weightedGrade = CalculateRawPercentage(eval.PointsEarned, eval.PointsPossibleToDate) * eval.WeightAmount;
                     totalGrade += weightedGrade;
                 }
             }


### PR DESCRIPTION
- Corrected design flaw that relied on weighted Courses having their Evaluations pre-graded instead of using point values.
- Also added easier grade accessors